### PR TITLE
Support negative credits in account records

### DIFF
--- a/lib/taskjuggler/TjpSyntaxRules.rb
+++ b/lib/taskjuggler/TjpSyntaxRules.rb
@@ -63,11 +63,11 @@ EOT
   end
 
   def rule_accountCredit
-    pattern(%w( !valDate $STRING !number ), lambda {
-      AccountCredit.new(@val[0], @val[1], @val[2])
+    pattern(%w( !valDate $STRING !optionalMinus !number ), lambda {
+      AccountCredit.new(@val[0], @val[1], (@val[2] ? -1 : 1) * @val[3])
     })
     arg(1, 'description', 'Short description of the transaction')
-    arg(2, 'amount', 'Amount to be booked.')
+    arg(3, 'amount', 'Amount to be booked.')
   end
 
   def rule_accountCredits
@@ -169,7 +169,8 @@ EOT
     })
     doc('credits', <<'EOT'
 Book the specified amounts to the account at the specified date. The
-desciptions are just used for documentary purposes.
+desciptions are just used for documentary purposes. Credit amounts may
+also be negative to represent outgoing payments.
 EOT
        )
     example('Account', '1')

--- a/test/TestSuite/Syntax/Correct/Account.tjp
+++ b/test/TestSuite/Syntax/Correct/Account.tjp
@@ -7,7 +7,8 @@ project simple "Simple Project" "1.0" 2007-01-01 - 2007-01-30 {
 account project_cost "Project Costs"
 account payments "Customer Payments"{
   credits 2007-01-01 "Customer down payment" 500.0,
-          2007-01-14 "1st rate" 2000.0
+          2007-01-14 "1st rate" 2000.0,
+          2007-01-20 "Refund" -300.0
 }
 
 balance project_cost payments

--- a/test/term/ansicolor.rb
+++ b/test/term/ansicolor.rb
@@ -1,0 +1,14 @@
+module Term
+  module ANSIColor
+    @coloring = true
+    class << self
+      attr_accessor :coloring
+      [:red, :magenta, :blue, :green, :reset].each do |m|
+        define_method(m) { |*args| '' }
+      end
+    end
+    [:red, :magenta, :blue, :green, :reset].each do |m|
+      define_method(m) { |*args| '' }
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- allow an optional minus sign for credit amounts
- describe negative credit values in documentation
- test credit parsing with a negative value
- provide a minimal ANSIColor stub so tests run without the gem

## Testing
- `ruby -I . -I ../lib all.rb`