### PR TITLE
Add Dockerfile and README update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM ruby:3.1-slim
+RUN apt-get update && apt-get install -y git
+WORKDIR /app
+COPY . .
+RUN gem build taskjuggler.gemspec && gem install taskjuggler-*.gem
+ENTRYPOINT ["tj3"]

--- a/README.rdoc
+++ b/README.rdoc
@@ -88,6 +88,16 @@ browser is all you need for your work.
 
 Installation instructions can be found {here}[http://www.taskjuggler.org/tj3/manual/Installation.html#Installation].
 
+= Running with Docker
+
+You can build a Docker image for TaskJuggler:
+
+  docker build -t taskjuggler .
+
+Run TaskJuggler inside the container:
+
+  docker run --rm -v "$PWD":/data taskjuggler tj3 <options>
+
 = Introduction and Tutorial
 
 To learn more about how to use TaskJuggler please see the {user


### PR DESCRIPTION
## Summary
- create Dockerfile for building TaskJuggler gem
- document how to run TaskJuggler in Docker

## Testing
- `rake -T` *(fails: cannot load such file -- rspec)*