### PR TITLE
Add GitHub Actions test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,20 @@
+name: Test
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: |
+          echo "source 'https://rubygems.org'\ngemspec" > Gemfile
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '2.7'
+          bundler-cache: true
+      - run: bundle exec rake


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run tests on Ruby 2.7

## Testing
- `bundle install` *(fails: Could not fetch specs from https://rubygems.org)*
- `bundle exec rake` *(fails: Could not find gem 'rspec' in locally installed gems)*